### PR TITLE
[TS-65] Tratar CRUD da Lesson

### DIFF
--- a/backend/attendance/serializers.py
+++ b/backend/attendance/serializers.py
@@ -15,10 +15,14 @@ class SubjectSerializer(serializers.ModelSerializer):
 
 
 class LessonSerializer(serializers.ModelSerializer):
+    is_attendance_registrable = serializers.SerializerMethodField()
+    
+    def get_is_attendance_registrable(self, obj):
+        return obj.is_attendance_registrable
+    
     class Meta:
         model = Lesson
-        fields = "__all__"
-
+        excludes = ["is_manual_attendance_checked", "manual_attendance_last_time_edited"]
 
 class AttendanceSerializer(serializers.ModelSerializer):
     class Meta:
@@ -40,6 +44,7 @@ class LessonWithDetailsSerializer(serializers.ModelSerializer):
     subject = serializers.SerializerMethodField()
     course = serializers.SerializerMethodField()
     student_class = serializers.SerializerMethodField()
+    is_attendance_registrable = serializers.SerializerMethodField()
 
     def get_subject(self, obj):
         return obj.lesson_recurrency.subject.name
@@ -49,6 +54,9 @@ class LessonWithDetailsSerializer(serializers.ModelSerializer):
     
     def get_student_class(self, obj):
         return obj.lesson_recurrency.student_class.name
+    
+    def get_is_attendance_registrable(self, obj):
+        return obj.is_attendance_registrable
 
     class Meta:
         model = Lesson


### PR DESCRIPTION
## O que foi feito?
- Atualização dos serializers para exibir as infos corretas

## Como testar?
- Enviar requisição de retrieve ou list para o back 
- Usar as requisições de /lesson e /lesson_with_details
- Devem retornar o status de `is_attendance_registrable` e não retornar os de manual attendance